### PR TITLE
Removed dependence on physical_constants module

### DIFF
--- a/naff.f90
+++ b/naff.f90
@@ -29,9 +29,12 @@
 
 module naff_mod
 
-use physical_constants
+!use physical_constants
 
 implicit none
+
+integer, parameter :: rp = selected_real_kind(11)
+real(rp), parameter :: twopi = 6.28318530718
 
 contains
 


### PR DESCRIPTION
Definitions for rp and twopi added to naff.f90.  This makes the code no longer dependent on the physical_constants module.